### PR TITLE
Make VP-IO compile with VP updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += Resolver.bintrayRepo("bkirwi", "maven")
 
 libraryDependencies ++= Seq(
   "com.azavea"                  %% "vectorpipe"                  % "1.0.0-SNAPSHOT",
-  "com.monovore"                %% "decline"                     % "0.3.0",
+  "com.monovore"                %% "decline"                     % "0.4.0-M1",
   "org.apache.spark"            %% "spark-hive"                  % "2.2.0" % "provided",
   "org.locationtech.geotrellis" %% "geotrellis-s3"               % "1.2.0-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-spark"            % "1.2.0-SNAPSHOT",

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" %% "geotrellis-spark"            % "1.2.0-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-vector"           % "1.2.0-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-vectortile"       % "1.2.0-SNAPSHOT",
-  "org.typelevel"               %% "cats"                        % "0.9.0"
+  "org.typelevel"               %% "cats-core"                   % "1.0.0-MF"
 )
 
 /* Allow `run` to be used with Spark code, while assembling fat JARs w/o Spark bundled */

--- a/src/main/scala/vpio/IO.scala
+++ b/src/main/scala/vpio/IO.scala
@@ -66,7 +66,12 @@ object IO extends CommandApp(
 
           /* Assumes that OSM ORC is in LatLng */
           val latlngFeats: RDD[osm.OSMFeature] =
-            osm.toFeatures(ns.repartition(100), ws.repartition(10), rs)
+            osm.toFeatures(
+              VectorPipe.logToLog4j,
+              ns.repartition(100).map(_._2),
+              ws.repartition(10).map(_._2),
+              rs.map(_._2)
+            )
 
           /* Reproject into WebMercator, the default for VTs */
           val wmFeats: RDD[osm.OSMFeature] =
@@ -74,7 +79,7 @@ object IO extends CommandApp(
 
           /* Associated each Feature with a SpatialKey */
           val fgrid: RDD[(SpatialKey, Iterable[osm.OSMFeature])] =
-            VectorPipe.toGrid(Clip.byHybrid, VectorPipe.log4j, layout, wmFeats)
+            VectorPipe.toGrid(Clip.byHybrid, VectorPipe.logToLog4j, layout, wmFeats)
 
           /* Create the VectorTiles */
           val tiles: RDD[(SpatialKey, VectorTile)] =


### PR DESCRIPTION
Some naming changes and some slight type-handling was required to get things compiling. Unfortunately, `java.lang.NoSuchMethodError: cats.implicits$.catsStdInstancesForOption()Lcats/TraverseFilter` is being thrown on program start. The next steps for resolving this issue are less than obvious.